### PR TITLE
fixed invalid public error on login

### DIFF
--- a/app/Classes/Gitlab.php
+++ b/app/Classes/Gitlab.php
@@ -48,7 +48,7 @@ class Gitlab implements ProviderInterface
             'slug' => $slug ? $slug : Helper::slug($repo->path),
             'title' => $repo->path,
             'fullname' => $repo->name,
-            'is_private' => $repo->public == true,
+            'is_private' => $repo->visibility,
             'html_url' => $repo->http_url_to_repo,
             'description' => $repo->description,
             'fork' => null,


### PR DESCRIPTION
this fixes the 'invalid public' error you get when logging in, ... there might be some changes in the gitlab api
